### PR TITLE
Add JSF Whitelist

### DIFF
--- a/nohttp/src/main/resources/io/spring/nohttp/whitelist.txt
+++ b/nohttp/src/main/resources/io/spring/nohttp/whitelist.txt
@@ -233,3 +233,15 @@ https://www\.w3schools\.com/furniture
 ^http://xmlns\.jcp\.org/xml/ns/javaee.*
 ^http://xmlns\.jcp\.org/xml/ns/persistence/orm.*
 ^http://xmlns\.oracle\.com/weblogic/weblogic-web-app.*
+
+^http://xmlns\.jcp\.org/jsf
+^http://xmlns\.jcp\.org/jsf/html
+^http://xmlns\.jcp\.org/jsf/core
+^http://xmlns\.jcp\.org/jsf/facelets
+^http://xmlns\.jcp\.org/jsf/composite
+^http://xmlns\.jcp\.org/jsf/composite/.*
+^http://xmlns\.jcp\.org/jsp/jstl/core
+^http://xmlns\.jcp\.org/jsp/jstl/functions
+^http://xmlns\.jcp\.org/jsf/passthrough
+^http://primefaces.org/ui
+^http://bootsfaces.net/ui

--- a/nohttp/src/test/java/io/spring/nohttp/RegexPredicateTest.java
+++ b/nohttp/src/test/java/io/spring/nohttp/RegexPredicateTest.java
@@ -222,4 +222,20 @@ public class RegexPredicateTest {
 		assertThat(this.whitelist.test(url)).describedAs("Should not be whitelisted and is").isFalse();
 	}
 
+	@Test
+	//gh-28
+	public void testJsfTaglibs() {
+		assertWhitelisted("http://xmlns.jcp.org/jsf");
+		assertWhitelisted("http://xmlns.jcp.org/jsf/html");
+		assertWhitelisted("http://xmlns.jcp.org/jsf/core");
+		assertWhitelisted("http://xmlns.jcp.org/jsf/facelets");
+		assertWhitelisted("http://xmlns.jcp.org/jsf/composite");
+		assertWhitelisted("http://xmlns.jcp.org/jsf/composite/foo-bar");
+		assertWhitelisted("http://xmlns.jcp.org/jsp/jstl/core");
+		assertWhitelisted("http://xmlns.jcp.org/jsp/jstl/functions");
+		assertWhitelisted("http://xmlns.jcp.org/jsf/passthrough");
+		assertWhitelisted("http://primefaces.org/ui");
+		assertWhitelisted("http://bootsfaces.net/ui");
+	}
+
 }


### PR DESCRIPTION
fixes #28 

Should all the `xmlns.jcp.org` urls be whitelisted separately or can we just whitelist `xmlns.jcp.org/jsf/**` or `xmlns.jcp.org/**`?