### PR TITLE
Ensure 'checkstyleNohttp' task is cacheable

### DIFF
--- a/nohttp-checkstyle/src/test/java/io/spring/nohttp/checkstyle/check/NoHttpCheckITest.java
+++ b/nohttp-checkstyle/src/test/java/io/spring/nohttp/checkstyle/check/NoHttpCheckITest.java
@@ -146,9 +146,9 @@ public class NoHttpCheckITest {
 			Properties properties = new Properties();
 			File whitelistFile = new File(WHITELIST_DIR, this.name + ".lines");
 			if (whitelistFile.exists()) {
-				properties.put("nohttp.checkstyle.whitelistFileName", whitelistFile.getAbsolutePath());
+				properties.put("nohttp.checkstyle.whitelistFileName", whitelistFile.getPath());
 			}
-			properties.put("config_loc", WHITELIST_DIR.getAbsolutePath());
+			properties.put("config_loc", WHITELIST_DIR.getPath());
 			this.properties = properties;
 			this.assersionsListener = new AssertionsAuditListener(
 					readChecks(this.name + ".txt"));

--- a/nohttp-gradle/src/main/java/io/spring/nohttp/gradle/NoHttpCheckstylePlugin.java
+++ b/nohttp-gradle/src/main/java/io/spring/nohttp/gradle/NoHttpCheckstylePlugin.java
@@ -155,9 +155,9 @@ public class NoHttpCheckstylePlugin implements Plugin<Project> {
 				File whitelistFile = extension.getWhitelistFile();
 				if (whitelistFile != null) {
 					logger.debug("Using whitelist at {}", whitelistFile);
-					configProperties.put("nohttp.checkstyle.whitelistFileName", whitelistFile);
+					configProperties.put("nohttp.checkstyle.whitelistFileName", project.relativePath(whitelistFile));
 				}
-				configProperties.put("config_loc", getConfigLocation());
+				configProperties.put("config_loc", project.relativePath(getConfigLocation()));
 				return configProperties;
 			}
 		});

--- a/nohttp-gradle/src/test/kotlin/io/spring/nohttp/gradle/NoHttpCheckstylePluginTest.kt
+++ b/nohttp-gradle/src/test/kotlin/io/spring/nohttp/gradle/NoHttpCheckstylePluginTest.kt
@@ -226,7 +226,7 @@ class NoHttpCheckstylePluginTest {
     -->
     <module name="SuppressWithPlainTextCommentFilter"/>
 </module>""")
-        assertThat(task.configProperties).containsEntry("config_loc", project.file("etc/nohttp"))
+        assertThat(task.configProperties).containsEntry("config_loc", project.relativePath("etc/nohttp"))
         assertThat(task.reports.xml.destination).isEqualTo(project.file("build/reports/checkstyle/nohttp.xml"))
         assertThat(task.reports.html.destination).isEqualTo(project.file("build/reports/checkstyle/nohttp.html"))
         assertThat(task.isIgnoreFailures).isFalse()
@@ -244,7 +244,7 @@ class NoHttpCheckstylePluginTest {
 
         val task: Checkstyle = project.tasks.findByName(NoHttpCheckstylePlugin.CHECKSTYLE_NOHTTP_TASK_NAME)!! as Checkstyle
 
-        assertThat(task.configProperties).containsEntry("config_loc", project.file("etc/nohttp"))
+        assertThat(task.configProperties).containsEntry("config_loc", project.relativePath("etc/nohttp"))
     }
 
     @Test
@@ -256,7 +256,7 @@ class NoHttpCheckstylePluginTest {
 
         val task: Checkstyle = project.tasks.findByName(NoHttpCheckstylePlugin.CHECKSTYLE_NOHTTP_TASK_NAME)!! as Checkstyle
 
-        assertThat(task.configProperties).containsEntry("nohttp.checkstyle.whitelistFileName", project.file("etc/nohttp/whitelist.lines"))
+        assertThat(task.configProperties).containsEntry("nohttp.checkstyle.whitelistFileName", project.relativePath("etc/nohttp/whitelist.lines"))
     }
 
     @Test
@@ -267,7 +267,7 @@ class NoHttpCheckstylePluginTest {
 
         val task: Checkstyle = project.tasks.findByName(NoHttpCheckstylePlugin.CHECKSTYLE_NOHTTP_TASK_NAME)!! as Checkstyle
 
-        assertThat(task.configProperties).containsEntry("config_loc", project.file("config/nohttp"))
+        assertThat(task.configProperties).containsEntry("config_loc", project.relativePath("config/nohttp"))
     }
 
     @Test
@@ -279,7 +279,7 @@ class NoHttpCheckstylePluginTest {
 
         val task: Checkstyle = project.tasks.findByName(NoHttpCheckstylePlugin.CHECKSTYLE_NOHTTP_TASK_NAME)!! as Checkstyle
 
-        assertThat(task.configProperties).containsEntry("nohttp.checkstyle.whitelistFileName", project.file("config/nohttp/whitelist.lines"))
+        assertThat(task.configProperties).containsEntry("nohttp.checkstyle.whitelistFileName", project.relativePath("config/nohttp/whitelist.lines"))
     }
 
     @Test
@@ -291,8 +291,8 @@ class NoHttpCheckstylePluginTest {
 
         val task: Checkstyle = project.tasks.findByName(NoHttpCheckstylePlugin.CHECKSTYLE_NOHTTP_TASK_NAME)!! as Checkstyle
 
-        assertThat(task.configProperties).containsEntry("nohttp.checkstyle.whitelistFileName", whitelistFile)
-        assertThat(task.configProperties).containsEntry("config_loc", whitelistFile.parentFile)
+        assertThat(task.configProperties).containsEntry("nohttp.checkstyle.whitelistFileName", project.relativePath(whitelistFile))
+        assertThat(task.configProperties).containsEntry("config_loc", project.relativePath(whitelistFile.parentFile))
     }
 
     @Test
@@ -306,8 +306,8 @@ class NoHttpCheckstylePluginTest {
         nohttp.whitelistFile = whitelistFile
         val task: Checkstyle = project.tasks.findByName(NoHttpCheckstylePlugin.CHECKSTYLE_NOHTTP_TASK_NAME)!! as Checkstyle
 
-        assertThat(task.configProperties).containsEntry("nohttp.checkstyle.whitelistFileName", whitelistFile)
-        assertThat(task.configProperties).containsEntry("config_loc", whitelistFile.parentFile)
+        assertThat(task.configProperties).containsEntry("nohttp.checkstyle.whitelistFileName", project.relativePath(whitelistFile))
+        assertThat(task.configProperties).containsEntry("config_loc", project.relativePath(whitelistFile.parentFile))
     }
 
     @Test


### PR DESCRIPTION
by writing relative paths to 'configProperties' input properties, instead of absolute paths