### PR TITLE
Avoid deprecation warnings when using Gradle 6

### DIFF
--- a/nohttp-gradle/src/test/kotlin/io/spring/nohttp/gradle/NoHttpCheckstylePluginITest.kt
+++ b/nohttp-gradle/src/test/kotlin/io/spring/nohttp/gradle/NoHttpCheckstylePluginITest.kt
@@ -102,12 +102,24 @@ class NoHttpCheckstylePluginITest {
         assertThat(checkstyleNohttpTaskOutcome(fromCacheResult)).isEqualTo(TaskOutcome.FROM_CACHE)
     }
 
+    @Test
+    fun noDeprecationWarningsWithGradle6() {
+        buildFile()
 
+        tempBuild.newFile("has-https.txt")
+                .writeText("""https://example.com""")
+
+        val result = runner(gradleVersion = "6.0.1").build()
+        println(result.output)
+        assertThat(result.output).doesNotContain("deprecation")
+        assertThat(checkstyleNohttpTaskOutcome(result)).isEqualTo(TaskOutcome.SUCCESS)
+    }
+    
     fun checkstyleNohttpTaskOutcome(build: BuildResult): TaskOutcome? {
         return build.task(":" + NoHttpCheckstylePlugin.CHECKSTYLE_NOHTTP_TASK_NAME)?.outcome
     }
 
-    fun runner(projectDir: File = tempBuild.root, testKitDir: File? = null): GradleRunner {
+    fun runner(projectDir: File = tempBuild.root, testKitDir: File? = null, gradleVersion: String? = null): GradleRunner {
         var gradleRunner = GradleRunner.create()
                 .withProjectDir(projectDir)
                 .withPluginClasspath()
@@ -115,6 +127,9 @@ class NoHttpCheckstylePluginITest {
         if (testKitDir != null) {
             args.add("--build-cache")
             gradleRunner = gradleRunner.withTestKitDir(testKitDir)
+        }
+        if (gradleVersion != null) {
+            gradleRunner = gradleRunner.withGradleVersion(gradleVersion)
         }
         return gradleRunner.withArguments(args)
     }


### PR DESCRIPTION
This pull request addresses https://github.com/spring-io/nohttp/issues/25 as best we can. It uses `configDirectory` when available (Gradle 6+), falling back to `configDir` and `config_loc` with Gradle 5. This ensures that no deprecation warnings are reported when using Gradle 6 while also providing better up-to-date checking with both Gradle 5 and Gradle 6. A deprecation warning will still be logged with Gradle 5 as we have to configure `config_loc`.