### PR TITLE
Only set config_loc if config dir does not exist

### DIFF
--- a/nohttp-gradle/src/main/java/io/spring/nohttp/gradle/NoHttpCheckstylePlugin.java
+++ b/nohttp-gradle/src/main/java/io/spring/nohttp/gradle/NoHttpCheckstylePlugin.java
@@ -219,7 +219,7 @@ public class NoHttpCheckstylePlugin implements Plugin<Project> {
 	}
 
 	private boolean configureConfigDirectory(Checkstyle checkstyleTask) {
-		File configDirectory = new File(this.project.relativePath(getConfigLocation()));
+		File configDirectory = this.project.file(getConfigLocation());
 		if (!configDirectory.exists() && isAtLeastGradle7()) {
 			return true;
 		}

--- a/nohttp-gradle/src/main/java/io/spring/nohttp/gradle/NoHttpCheckstylePlugin.java
+++ b/nohttp-gradle/src/main/java/io/spring/nohttp/gradle/NoHttpCheckstylePlugin.java
@@ -221,7 +221,8 @@ public class NoHttpCheckstylePlugin implements Plugin<Project> {
 	private boolean configureConfigDirectory(Checkstyle checkstyleTask) {
 		File configDirectory = this.project.file(getConfigLocation());
 		if (!configDirectory.exists() && isAtLeastGradle7()) {
-			return true;
+			File defaultConfigDir = checkstyleTask.getConfigDirectory().getAsFile().forUseAtConfigurationTime().getOrNull();
+			return defaultConfigDir == null || !defaultConfigDir.exists();
 		}
 		try {
 			checkstyleTask.getConfigDirectory().set(configDirectory);

--- a/nohttp-gradle/src/test/kotlin/io/spring/nohttp/gradle/NoHttpCheckstylePluginITest.kt
+++ b/nohttp-gradle/src/test/kotlin/io/spring/nohttp/gradle/NoHttpCheckstylePluginITest.kt
@@ -137,6 +137,26 @@ class NoHttpCheckstylePluginITest {
                 .contains("configDirectory = ${configDirectory.canonicalPath}")
     }
 
+    @Test
+    fun worksIfCheckstyleConfigIsPresentInDefaultLocation() {
+        val configDirectory = tempBuild.newFolder("config", "checkstyle")
+        File(configDirectory, "checkstyle.xml").writeText("""
+            <?xml version="1.0"?>
+            <!DOCTYPE module PUBLIC
+                    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+                    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+            <module name="Checker">
+                <module name="NewlineAtEndOfFile">
+                    <property name="lineSeparator" value="lf"/>
+                </module>
+            </module>
+        """.trimIndent())
+        buildFile()
+
+        val result = runner().build()
+        assertThat(checkstyleNohttpTaskOutcome(result)).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
     fun checkstyleNohttpTaskOutcome(build: BuildResult): TaskOutcome? {
         return build.task(":" + NoHttpCheckstylePlugin.CHECKSTYLE_NOHTTP_TASK_NAME)?.outcome
     }


### PR DESCRIPTION
Follow-up on #43.
Fixes #44.