### PR TITLE
Add support for Gradle 7.0.1

### DIFF
--- a/nohttp-gradle/src/main/java/io/spring/nohttp/gradle/NoHttpCheckstylePlugin.java
+++ b/nohttp-gradle/src/main/java/io/spring/nohttp/gradle/NoHttpCheckstylePlugin.java
@@ -220,7 +220,7 @@ public class NoHttpCheckstylePlugin implements Plugin<Project> {
 
 	private boolean configureConfigDirectory(Checkstyle checkstyleTask) {
 		File configDirectory = this.project.file(getConfigLocation());
-		if (!configDirectory.exists() && isAtLeastGradle7()) {
+		if (!configDirectory.exists() && isGradle7_0()) {
 			File defaultConfigDir = checkstyleTask.getConfigDirectory().getAsFile().forUseAtConfigurationTime().getOrNull();
 			return defaultConfigDir == null || !defaultConfigDir.exists();
 		}
@@ -240,8 +240,8 @@ public class NoHttpCheckstylePlugin implements Plugin<Project> {
 		}
 	}
 
-	private boolean isAtLeastGradle7() {
-		return GradleVersion.current().getBaseVersion().compareTo(GradleVersion.version("7.0")) >= 0;
+	private boolean isGradle7_0() {
+		return GradleVersion.current().getBaseVersion().equals(GradleVersion.version("7.0"));
 	}
 
 	private File getConfigLocation() {

--- a/nohttp-gradle/src/test/kotlin/io/spring/nohttp/gradle/NoHttpCheckstylePluginITest.kt
+++ b/nohttp-gradle/src/test/kotlin/io/spring/nohttp/gradle/NoHttpCheckstylePluginITest.kt
@@ -50,7 +50,7 @@ class NoHttpCheckstylePluginITest {
     companion object {
         @Parameters(name = "{0}")
         @JvmStatic
-        fun gradleVersions() = listOf("6.0.1", "6.8.3", "7.0").map(GradleVersion::version)
+        fun gradleVersions() = listOf("6.0.1", "6.8.3", "7.0", "7.0.1").map(GradleVersion::version)
     }
 
     @Parameter


### PR DESCRIPTION
Due to gradle/gradle#17015, the previous fix for Gradle 7.0 is no longer
necessary for >= 7.0.1.

---

Please note that the plugin currently causes failure on Gradle 7.0.1:
https://ge.junit.org/s/l5huwiqbvbb2g/failure#1

Hence, a release after merging this PR would be appreciated. 😉 