### PR TITLE
Update nohttp-gradle/README.adoc to use 0.0.8

### DIFF
--- a/nohttp-gradle/README.adoc
+++ b/nohttp-gradle/README.adoc
@@ -17,7 +17,7 @@ For example in Groovy:
 [source,groovy]
 ----
 plugins {
-	id "io.spring.nohttp" version "0.0.6.RELEASE"
+	id "io.spring.nohttp" version "0.0.8"
 }
 
 nohttp {
@@ -31,7 +31,7 @@ Or in Kotlin:
 [source,kotlin]
 ----
 plugins {
-	id("io.spring.nohttp") version "0.0.6.RELEASE"
+	id("io.spring.nohttp") version "0.0.8"
 }
 
 nohttp {


### PR DESCRIPTION
This PR updates `nohttp-gradle/README.adoc` to use the latest version (0.0.8).