### PR TITLE
Fix Gradle 7.1 deprecation warnings

### DIFF
--- a/nohttp-gradle/src/main/java/io/spring/nohttp/gradle/NoHttpCheckstylePlugin.java
+++ b/nohttp-gradle/src/main/java/io/spring/nohttp/gradle/NoHttpCheckstylePlugin.java
@@ -163,7 +163,9 @@ public class NoHttpCheckstylePlugin implements Plugin<Project> {
 		checkstyleTask.getReports().all(new Action<SingleFileReport>() {
 			@Override
 			public void execute(final SingleFileReport report) {
-				String reportFileName = report.getDestination().getName();
+				String reportFileName = isAtLeastGradle7() ?
+					report.getOutputLocation().get().getAsFile().getName() :
+					report.getDestination().getName();
 				report.setDestination(project.getExtensions().getByType(ReportingExtension.class)
 						.getBaseDirectory()
 						.dir(checkstyleTask.getName())
@@ -238,6 +240,10 @@ public class NoHttpCheckstylePlugin implements Plugin<Project> {
 			// Fall back to config_loc
 			return true;
 		}
+	}
+
+	public static boolean isAtLeastGradle7() {
+		return GradleVersion.current().getBaseVersion().compareTo(GradleVersion.version("7.0")) >= 0;
 	}
 
 	private boolean isGradle7_0() {

--- a/nohttp-gradle/src/main/java/io/spring/nohttp/gradle/NoHttpCliPlugin.java
+++ b/nohttp-gradle/src/main/java/io/spring/nohttp/gradle/NoHttpCliPlugin.java
@@ -8,11 +8,14 @@ import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.tasks.JavaExec;
 
 import static io.spring.nohttp.gradle.NoHttpCheckstylePlugin.NOHTTP_EXTENSION_NAME;
+import static io.spring.nohttp.gradle.NoHttpCheckstylePlugin.isAtLeastGradle7;
 
 /**
  * @author Rob Winch
  */
 public class NoHttpCliPlugin implements Plugin<Project> {
+	private static final String MAIN_CLASS = "io.spring.nohttp.cli.NoHttpCliMain";
+
 	private Project project;
 
 	private NoHttpExtension extension;
@@ -28,7 +31,11 @@ public class NoHttpCliPlugin implements Plugin<Project> {
 		JavaExec nohttp = project.getTasks().create("nohttp", JavaExec.class);
 		nohttp.setDescription("Runs nohttp");
 
-		nohttp.setMain("io.spring.nohttp.cli.NoHttpCliMain");
+		if (isAtLeastGradle7()) {
+			nohttp.getMainClass().set(MAIN_CLASS);
+		} else {
+			nohttp.setMain(MAIN_CLASS);
+		}
 		nohttp.setClasspath(nohttpCli);
 	}
 

--- a/nohttp-gradle/src/test/kotlin/io/spring/nohttp/gradle/NoHttpCheckstylePluginITest.kt
+++ b/nohttp-gradle/src/test/kotlin/io/spring/nohttp/gradle/NoHttpCheckstylePluginITest.kt
@@ -50,7 +50,7 @@ class NoHttpCheckstylePluginITest {
     companion object {
         @Parameters(name = "{0}")
         @JvmStatic
-        fun gradleVersions() = listOf("6.0.1", "6.8.3", "7.0", "7.0.1").map(GradleVersion::version)
+        fun gradleVersions() = listOf("6.0.1", "6.8.3", "7.0", "7.0.1", "7.1").map(GradleVersion::version)
     }
 
     @Parameter


### PR DESCRIPTION
Fixes #49 

cc @rwinch

Not sure how to test this as any Gradle command that I run leads to:

```
No such property: COMPILE_CONFIGURATION_NAME for class: org.gradle.api.plugins.JavaPlugin
```

Any ideas?