### PR TITLE
Bump documented version references

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
 buildscript {
 	dependencies {
 		classpath 'io.spring.gradle:spring-build-conventions:0.0.37'
-		classpath 'io.spring.nohttp:nohttp-gradle:0.0.5.RELEASE'
+		classpath 'io.spring.nohttp:nohttp-gradle:0.0.10'
 	}
 	repositories {
 		maven { url 'https://plugins.gradle.org/m2/' }

--- a/nohttp-cli/README.adoc
+++ b/nohttp-cli/README.adoc
@@ -16,7 +16,7 @@ For example:
 
 [source,bash]
 ----
-export NOHTTP='~/Downloads/nohttp-cli-0.0.1.BUILD-SNAPSHOT.jar'
+export NOHTTP='~/Downloads/nohttp-cli-0.0.10.jar'
 ----
 
 == Compiling
@@ -28,17 +28,17 @@ To use this app first create the jar
 ./gradlew :nohttp-cli:assemble
 ----
 
-The jar will now available at `nohttp-cli/build/libs/nohttp-cli-0.0.1.BUILD-SNAPSHOT.jar`.
+The jar will now available at `nohttp-cli/build/libs/nohttp-cli-0.0.11-SNAPSHOT`.
 
 You can then export the full path to a variable.
 
 [source,bash]
 ----
-export NOHTTP=$(pwd)/nohttp-cli/build/libs/nohttp-cli-0.0.1.BUILD-SNAPSHOT.jar
+export NOHTTP=$(pwd)/nohttp-cli/build/libs/nohttp-cli-0.0.11-SNAPSHOT.jar
 ----
 
 The guide assumes that the jar is now available in the variable `$NOHTTP`.
-If that is not true, you can substitute `$NOHTTP` for the absolute path of `nohttp-cli-0.0.1.BUILD-SNAPSHOT.jar`.
+If that is not true, you can substitute `$NOHTTP` for the absolute path of `nohttp-cli-0.0.11-SNAPSHOT.jar`.
 
 == Running
 

--- a/nohttp-gradle/README.adoc
+++ b/nohttp-gradle/README.adoc
@@ -103,7 +103,7 @@ The https://github.com/spring-io/nohttp/blob/main/nohttp-gradle/src/main/java/io
 nohttp {
     allowlistFile = project.file('src/nohttp/allowlist.lines') <1>
     source.exclude "**/test-output/**"                         <2>
-    toolVersion = '0.0.1.BUILD-SNAPSHOT'                       <3>
+    toolVersion = '0.0.10'                                     <3>
 }
 ----
 

--- a/samples/nohttp-maven-sample/pom.xml
+++ b/samples/nohttp-maven-sample/pom.xml
@@ -32,17 +32,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.1.2</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.33</version>
+                        <version>10.3.2</version>
                     </dependency>
                     <dependency>
                         <groupId>io.spring.nohttp</groupId>
                         <artifactId>nohttp-checkstyle</artifactId>
-                        <version>0.0.4.RELEASE</version>
+                        <version>0.0.10</version>
                     </dependency>
                 </dependencies>
                 <configuration>


### PR DESCRIPTION
While there, update the build to use a more recent version of `nohttp-gradle`.