### PR TITLE
Avoid project reference in registered `all` action

### DIFF
--- a/nohttp-gradle/src/main/java/io/spring/nohttp/gradle/NoHttpCheckstylePlugin.java
+++ b/nohttp-gradle/src/main/java/io/spring/nohttp/gradle/NoHttpCheckstylePlugin.java
@@ -161,12 +161,12 @@ public class NoHttpCheckstylePlugin implements Plugin<Project> {
 		Logger logger = this.logger;
 		NoHttpExtension extension = this.extension;
 		checkstyleTask.setDescription("Checks for illegal uses of http://");
+		Provider<Directory> reportDir = project.getExtensions().getByType(ReportingExtension.class)
+				.getBaseDirectory()
+				.dir(checkstyleTask.getName());
 		checkstyleTask.getReports().all(new Action<SingleFileReport>() {
 			@Override
 			public void execute(final SingleFileReport report) {
-				Provider<Directory> reportDir = project.getExtensions().getByType(ReportingExtension.class)
-						.getBaseDirectory()
-						.dir(checkstyleTask.getName());
 				if (isAtLeastGradle7()) {
 					String reportFileName = report.getOutputLocation().get().getAsFile().getName();
 					report.getOutputLocation().value(reportDir.map(it -> it.file(reportFileName)));


### PR DESCRIPTION
Unfortunately, I couldn't import the project locally due to:

```
A problem occurred configuring root project 'nohttp-build'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not resolve io.spring.gradle:spring-build-conventions:0.0.38.
     Required by:
         project :
      > Could not resolve io.spring.gradle:spring-build-conventions:0.0.38.
         > Could not get resource 'https://repo.spring.io/plugins-release/io/spring/gradle/spring-build-conventions/0.0.38/spring-build-conventions-0.0.38.pom'.
            > Could not GET 'https://repo.spring.io/plugins-release/io/spring/gradle/spring-build-conventions/0.0.38/spring-build-conventions-0.0.38.pom'. Received status code 401 from server
```

Resolves #61.